### PR TITLE
Fix dashboard data loading by updating targetPluginId

### DIFF
--- a/workspaces/mend/.changeset/orange-bobcats-compete.md
+++ b/workspaces/mend/.changeset/orange-bobcats-compete.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-mend-backend': patch
+---
+
+Updated the targetPluginId from 'plugin.catalog.service' to 'catalog' to get the correct token

--- a/workspaces/mend/plugins/mend-backend/src/service/router.ts
+++ b/workspaces/mend/plugins/mend-backend/src/service/router.ts
@@ -94,7 +94,7 @@ export async function createRouter(
       const credentials = await httpAuth.credentials(request);
       const { token } = await auth.getPluginRequestToken({
         onBehalfOf: credentials,
-        targetPluginId: 'plugin.catalog.service',
+        targetPluginId: 'catalog',
       });
 
       // entity to project match
@@ -154,7 +154,7 @@ export async function createRouter(
       const credentials = await httpAuth.credentials(request);
       const { token } = await auth.getPluginRequestToken({
         onBehalfOf: credentials,
-        targetPluginId: 'plugin.catalog.service',
+        targetPluginId: 'catalog',
       });
 
       // entity to project match


### PR DESCRIPTION
Updated the targetPluginId from 'plugin.catalog.service' to 'catalog' to ensure the correct token is retrieved. This resolves the issue where dashboard data was not populating.

## Hey, I just made a Pull Request!

- Update targetPluginId from 'plugin.catalog.service' to 'catalog' to retrieve correct token
- Added Changeset based on the changes
<img width="1512" height="820" alt="image" src="https://github.com/user-attachments/assets/c3df3f2d-230e-45d1-94e9-f459b1f64d34" />

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal plugin identifier to improve service authentication reliability. No changes to user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->